### PR TITLE
Add conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
         over time similar to <a href="#relationship-to-apis-in-other-platforms">other platforms</a>.
       </p>
     </section>
+    <section id='conformance'></section>
     <section dfn-for="InputDeviceCapabilities">
       <h2>The <code>InputDeviceCapabilities</code> interface</h2>
       <p>


### PR DESCRIPTION
Fixes "Normative references in informative sections are not allowed" warning message reported by ReSpec.

The warning appeared because Respec assumes that a spec is informative-only in the absence of a conformance section, see discussion in:
https://github.com/w3c/respec/issues/2580